### PR TITLE
feat: add linear scan example

### DIFF
--- a/nada-project.toml
+++ b/nada-project.toml
@@ -180,3 +180,8 @@ prime_size = 128
 path = "src/random_number.py"
 name = "random_number"
 prime_size = 128
+
+[[programs]]
+path = "src/list_scan_linear.py"
+name = "list_scan_linear"
+prime_size = 128

--- a/src/list_scan_linear.py
+++ b/src/list_scan_linear.py
@@ -1,0 +1,30 @@
+from nada_dsl import *
+import nada_numpy as na
+
+def is_number_present_in_list(array: List[SecretInteger], value: Integer) -> SecretBoolean:
+    result = Integer(0)
+    for element in array:
+        # If the element is equal to the value, add 1 to the result.
+        result += (value == element).if_else(Integer(1), Integer(0))
+    return (result > Integer(0))
+
+def nada_main():
+    num_parties = 10
+    parties = na.parties(num_parties)
+
+    secrets_list = []
+    for i in range(num_parties):
+        secrets_list.append(
+            SecretInteger(Input(name="num_" + str(i), party=parties[i]))
+        )
+
+    # Check if 100 is present in one of the parties.
+    is_present_1 = is_number_present_in_list(secrets_list, Integer(100))
+
+    # Check if 99 is present in one of the parties.
+    is_present_2 = is_number_present_in_list(secrets_list, Integer(99))
+
+    return [
+        Output(is_present_1, "is_present_1", party=parties[0]),
+        Output(is_present_2, "is_present_2", party=parties[0]),
+    ]

--- a/tests/list_scan_linear_test.yaml
+++ b/tests/list_scan_linear_test.yaml
@@ -1,0 +1,28 @@
+---
+program: list_scan_linear
+inputs:
+  num_0:
+    SecretInteger: "10"
+  num_2:
+    SecretInteger: "20"
+  num_1:
+    SecretInteger: "30"
+  num_4:
+    SecretInteger: "40"
+  num_9:
+    SecretInteger: "50"
+  num_6:
+    SecretInteger: "60"
+  num_7:
+    SecretInteger: "70"
+  num_8:
+    SecretInteger: "80"
+  num_5:
+    SecretInteger: "90"
+  num_3:
+    SecretInteger: "100"
+expected_outputs:
+  is_present_1:
+    SecretBoolean: true
+  is_present_2:
+    SecretBoolean: false


### PR DESCRIPTION
Running:
```bash
nada test list_scan_linear_test
```
checks if 100 and 99 exist in a list of secret integers and returns `true` and `false`, respectively.