### PR TITLE
Add Newton-Ramson cube root approximation

### DIFF
--- a/nada-project.toml
+++ b/nada-project.toml
@@ -210,3 +210,8 @@ prime_size = 128
 path = "src/square_root.py"
 name = "square_root"
 prime_size = 128
+
+[[programs]]
+path = "src/cube_root.py"
+name = "cube_root"
+prime_size = 128

--- a/src/cube_root.py
+++ b/src/cube_root.py
@@ -1,0 +1,24 @@
+"""Implementation of the square root function using the Newton method
+with n iterations - set to 41 by default."""
+
+from nada_dsl import *
+import time
+
+n_iterations = 41
+def nada_main():
+
+    party1 = Party(name="Party1")
+
+    num = SecretInteger(Input(name="num", party=party1))
+    guess = num
+
+    for _ in range(n_iterations):
+        div1 = guess / Integer(3)
+        div2 = num / guess
+        div2 = div2 / guess
+        div2 = div2 / Integer(3)
+        guess = Integer(2) * div1 +  div2
+    return [Output(guess, "my_output", party1)]
+
+if __name__ == "__main__":
+   nada_main()

--- a/src/cube_root.py
+++ b/src/cube_root.py
@@ -13,11 +13,12 @@ def nada_main():
     guess = num
 
     for _ in range(n_iterations):
-        div1 = guess / Integer(3)
+        div1 = guess
         div2 = num / guess
         div2 = div2 / guess
-        div2 = div2 / Integer(3)
+        # div2 = div2 / Integer(3)
         guess = Integer(2) * div1 +  div2
+        guess = guess / Integer(3)
     return [Output(guess, "my_output", party1)]
 
 if __name__ == "__main__":

--- a/src/cube_root.py
+++ b/src/cube_root.py
@@ -1,4 +1,4 @@
-"""Implementation of the square root function using the Newton method
+"""Implementation of the cube root function using the Newton method
 with n iterations - set to 41 by default."""
 
 from nada_dsl import *

--- a/src/cube_root.py
+++ b/src/cube_root.py
@@ -16,7 +16,6 @@ def nada_main():
         div1 = guess
         div2 = num / guess
         div2 = div2 / guess
-        # div2 = div2 / Integer(3)
         guess = Integer(2) * div1 +  div2
         guess = guess / Integer(3)
     return [Output(guess, "my_output", party1)]

--- a/tests/cube_root_test.yaml
+++ b/tests/cube_root_test.yaml
@@ -1,0 +1,8 @@
+---
+program: cube_root
+inputs:
+  num:
+    SecretInteger: "127324"
+expected_outputs:
+  my_output:
+    SecretInteger: "1"

--- a/tests/cube_root_test.yaml
+++ b/tests/cube_root_test.yaml
@@ -5,4 +5,4 @@ inputs:
     SecretInteger: "127324"
 expected_outputs:
   my_output:
-    SecretInteger: "1"
+    SecretInteger: "50"

--- a/tests/cube_root_test.yaml
+++ b/tests/cube_root_test.yaml
@@ -1,8 +1,0 @@
----
-program: cube_root
-inputs:
-  num:
-    SecretInteger: "127324"
-expected_outputs:
-  my_output:
-    SecretInteger: "50"

--- a/tests/cube_root_test1.yaml
+++ b/tests/cube_root_test1.yaml
@@ -1,0 +1,8 @@
+---
+program: cube_root
+inputs:
+  num:
+    SecretInteger: "127324"
+expected_outputs:
+  my_output:
+    SecretInteger: "50"

--- a/tests/cube_root_test2.yaml
+++ b/tests/cube_root_test2.yaml
@@ -1,0 +1,8 @@
+---
+program: cube_root
+inputs:
+  num:
+    SecretInteger: "27"
+expected_outputs:
+  my_output:
+    SecretInteger: "3"

--- a/tests/cube_root_test3.yaml
+++ b/tests/cube_root_test3.yaml
@@ -1,0 +1,8 @@
+---
+program: cube_root
+inputs:
+  num:
+    SecretInteger: "734523"
+expected_outputs:
+  my_output:
+    SecretInteger: "90"

--- a/tests/cube_root_test4.yaml
+++ b/tests/cube_root_test4.yaml
@@ -1,0 +1,8 @@
+---
+program: cube_root
+inputs:
+  num:
+    SecretInteger: "3245"
+expected_outputs:
+  my_output:
+    SecretInteger: "14"


### PR DESCRIPTION
# New Nada Example

- [x] I have read the [contributing docs](/NillionNetwork/nada-by-example/blob/main/CONTRIBUTING.md)
- [x] This is not a duplicate of any [existing pull request](https://github.com/NillionNetwork/nada-by-example/pulls)

## Description

Using Newtons method to approximate the cube root function.  Function takes input `x` and returns integer cube root value `s`.

The number of loop iterations for this method should be 11 for 8-bit numbers, 22 for 16-bit numbers and 41 for 32-bit numbers. It is currently set to 41. 

## Use Case

Polynomial evaluation.

## Related Issues

The function overflows for large integers, and will return incorrect results.
```

## Optional: add your information for a Nada by Example Contributor POAP

Your Twitter:
Your Ethereum address:
