### PR TITLE
feat: add not (~) operator

### DIFF
--- a/nada-project.toml
+++ b/nada-project.toml
@@ -226,3 +226,7 @@ path = "src/stdev_integer.py"
 name = "stdev_integer"
 prime_size = 128
 
+[[programs]]
+path = "src/not.py"
+name = "not"
+prime_size = 128

--- a/src/not.py
+++ b/src/not.py
@@ -1,0 +1,19 @@
+from nada_dsl import *
+
+def nada_main():
+    party_alice = Party(name="Alice")
+    party_bob = Party(name="Bob")
+    party_charlie = Party(name="Charlie")
+    
+    secret_target = SecretInteger(Input(name="secret_target", party=party_alice))
+    secret_guess = SecretInteger(Input(name="secret_guess", party=party_bob))
+    
+    # equal to check (==)
+    check_is_equal_to = secret_target == secret_guess
+    
+    # the not operator (~) is used to invert or negate a boolean value
+    check_is_not_equal_to = ~check_is_equal_to
+
+    return [
+        Output(check_is_not_equal_to, "check_is_not_equal_to", party_charlie),
+    ]

--- a/tests/not_test_1.yaml
+++ b/tests/not_test_1.yaml
@@ -1,0 +1,7 @@
+---
+program: not
+inputs:
+  secret_guess: 30
+  secret_target: 3
+expected_outputs:
+  check_is_not_equal_to: true

--- a/tests/not_test_2.yaml
+++ b/tests/not_test_2.yaml
@@ -1,0 +1,7 @@
+---
+program: not
+inputs:
+  secret_guess: 3
+  secret_target: 3
+expected_outputs:
+  check_is_not_equal_to: false


### PR DESCRIPTION
# New Nada Example

- [x] I have read the [contributing docs](/NillionNetwork/nada-by-example/blob/main/CONTRIBUTING.md)
- [x] This is not a duplicate of any [existing pull request](https://github.com/NillionNetwork/nada-by-example/pulls)

## Description

Describe the example you are adding. Provide a clear and concise summary of what the example does, its purpose, and the problem it solves. 

This example demonstrates how to use the ~ (not) operator in the Nada DSL to invert or negate a boolean value. The program compares two secret integers provided by different parties and then uses the ~ operator to determine if the two integers are not equal. The result is shared with a third party.

## Use Case

What are the target use cases for the example? 

The not operator (~) combined with equal to (==) can be combined to check not equal to since the != feature is not yet built into Nada.

## Related Issues

Link to the related issue if this PR solves an Issue.

## Optional: add your information for a Nada by Example Contributor POAP

Your Twitter: https://twitter.com/0ceans404
Your Ethereum address: oceans404.eth
