### PR TITLE
add Price is Right Game Nada example

### DIFF
--- a/src/price_is_right.py
+++ b/src/price_is_right.py
@@ -1,0 +1,34 @@
+from nada_dsl import *
+
+def nada_main():
+    price = Party(name="Price")
+    player1 = Party(name="Player1")
+    player2 = Party(name="Player2")
+
+    right_price = SecretInteger(Input(name="Price", party=price))
+    player1_input = SecretInteger(Input(name="Player1", party=player1))
+    player2_input = SecretInteger(Input(name="Player2", party=player2))
+
+    # calculate the difference between the guess and the price
+    # set the value to -1 if the guess is greater than the price
+    player1_close_value = (player1_input > right_price).if_else(Integer(-1), right_price - player1_input)
+    player2_close_value = (player2_input > right_price).if_else(Integer(-1), right_price - player2_input)
+
+    condition1 = player1_close_value < player2_close_value
+    exceeding_condition1 = player1_close_value == Integer(-1)
+    exceeding_condition2 = player2_close_value == Integer(-1)
+
+    # check who guess that is closest to the actual price 
+    result = condition1.if_else(Integer(1), Integer(2))
+
+    # check who guess exceed the actual price
+    result = exceeding_condition1.if_else(Integer(2), result)
+    result = exceeding_condition2.if_else(Integer(1), result)
+
+    # if all guesses exceed the actual price or if it a tie, return 0 for no winner
+    result = (player1_close_value == player2_close_value).if_else(Integer(0), result)
+    
+    # O - no winner
+    # 1 - player 1 win
+    # 2 - player 2 win
+    return [Output(result, "winner", price)]

--- a/tests/price_is_right.yaml
+++ b/tests/price_is_right.yaml
@@ -1,0 +1,12 @@
+---
+program: price_is_right
+inputs:
+  Price:
+    SecretInteger: "5"
+  Player1:
+    SecretInteger: "2"
+  Player2:
+    SecretInteger: "4"
+expected_outputs:
+  winner:
+    SecretInteger: "2"


### PR DESCRIPTION
# New Nada Example

- [x] I have read the [contributing docs](/NillionNetwork/nada-by-example/blob/main/CONTRIBUTING.md)
- [x] This is not a duplicate of any [existing pull request](https://github.com/NillionNetwork/nada-by-example/pulls)

## Description

I created Price is right game example.  It takes 3 inputs (Actual Price, Player 1, Player2).  It calculate the difference between the guesses and the actual price.  It returns the guess that is closest to the actual price without exceeding it (1 for Player 1, 2 for Player 2).  If all guesses exceed the actual price, it will return 0 for no winner.

## Use Case

Good example to help with game theory

## Related Issues

[Issues #10](https://github.com/NillionNetwork/nada-by-example/issues/10)

## Optional: add your information for a Nada by Example Contributor POAP

Your Twitter:
Your Ethereum address:
