### PR TITLE
add Matrix Scan Nada example and test

### DIFF
--- a/nada-project.toml
+++ b/nada-project.toml
@@ -253,3 +253,7 @@ prime_size = 128
 path = "src/auction_can_tie.py"
 name = "auction_can_tie"
 prime_size = 128
+
+[[programs]]
+path = "src/matrix_scan.py"
+prime_size = 128

--- a/src/matrix_scan.py
+++ b/src/matrix_scan.py
@@ -1,0 +1,52 @@
+from nada_dsl import *
+import nada_numpy as na
+
+# Return the all coordinates where the value excists
+def find_number_present_in_list(array: List[List[SecretInteger]], value: SecretInteger) -> List[List[Integer]]:
+    result = []
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            coordinate = []
+            # Get the coordinate[x, y].  If no match, set the coordinate to [-1, -1]
+            x = (value == array[i][j]).if_else(Integer(i), Integer(-1))
+            y = (value == array[i][j]).if_else(Integer(j), Integer(-1))
+            result.append([x,  y])
+
+    return result
+
+def nada_main():
+    num_row = 3
+    row = na.parties(num_row)
+
+    target_number = Party(name="target")
+    target_number = SecretInteger(Input(name="target_number", party=target_number))
+
+    # Create the matrix
+    matrix: list[list[SecretInteger]] = []
+    
+    # Get the user inputs for the first row and add it to the matrix
+    matrix_row_1 = []
+    for i in range(num_row):
+        matrix_row_1.append(
+            SecretInteger(Input(name="row_0_" + str(i), party=row[i]))
+        )
+    matrix.append(matrix_row_1)
+
+    # Get the user inputs for the second row and add it to the matrix
+    matrix_row_2 = []
+    for i in range(num_row):
+        matrix_row_2.append(
+            SecretInteger(Input(name="row_1_" + str(i), party=row[i]))
+        )
+    matrix.append(matrix_row_2)
+
+    # Scan a matrix for a specific value
+    value_excists = find_number_present_in_list(matrix, target_number)
+
+    outputs = []
+
+    for i in range(len(value_excists)):
+        outputs.append(Output(value_excists[i][0], "value_excists_" + str(i) + "_x",  party=row[0]))
+        outputs.append(Output(value_excists[i][1], "value_excists_" + str(i) + "_y",  party=row[0]))
+
+    return outputs

--- a/tests/matrix_scan_test.yaml
+++ b/tests/matrix_scan_test.yaml
@@ -1,0 +1,42 @@
+---
+program: matrix_scan
+inputs:
+  row_0_0:
+    SecretInteger: "1"
+  row_0_1:
+    SecretInteger: "2"
+  row_0_2:
+    SecretInteger: "3"
+  row_1_0:
+    SecretInteger: "2"
+  row_1_1:
+    SecretInteger: "1"
+  row_1_2:
+    SecretInteger: "3"
+  target_number:
+    SecretInteger: "3"
+expected_outputs:
+  value_excists_0_x:
+    SecretInteger: "-1"
+  value_excists_0_y:
+    SecretInteger: "-1"
+  value_excists_1_x:
+    SecretInteger: "-1"
+  value_excists_1_y:
+    SecretInteger: "-1"
+  value_excists_2_x:
+    SecretInteger: "0"
+  value_excists_2_y:
+    SecretInteger: "2"
+  value_excists_3_x:
+    SecretInteger: "-1"
+  value_excists_3_y:
+    SecretInteger: "-1"
+  value_excists_4_x:
+    SecretInteger: "-1"
+  value_excists_4_y:
+    SecretInteger: "-1"
+  value_excists_5_x:
+    SecretInteger: "1"
+  value_excists_5_y:
+    SecretInteger: "2"


### PR DESCRIPTION
# Matrix Scan Nada Example

- [x] I have read the [contributing docs](/NillionNetwork/nada-by-example/blob/main/CONTRIBUTING.md)
- [x] This is not a duplicate of any [existing pull request](https://github.com/NillionNetwork/nada-by-example/pulls)

## Description

I created a Matrix Scan example. It takes inputs for the first and second rows of the matrix and a target number to search for in the matrix. It scan the matrix for the specific value and returns the coordinates where the value exists. If the value is not found, it returns [-1, -1] to indicate no match.

## Use Case

Image processing and game development

## Related Issues

[Issue#9](https://github.com/NillionNetwork/nada-by-example/issues/9)

## Optional: add your information for a Nada by Example Contributor POAP

Your Twitter:
Your Ethereum address:
