### PR TITLE
feat: Add example of using Python builtin `sum()` for secret integers

### DIFF
--- a/nada-project.toml
+++ b/nada-project.toml
@@ -263,3 +263,8 @@ prime_size = 128
 path = "src/auction_can_tie.py"
 name = "auction_can_tie"
 prime_size = 128
+
+[[programs]]
+name = "sum_list"
+path = "src/sum_list.py"
+prime_size = 128

--- a/src/sum_list.py
+++ b/src/sum_list.py
@@ -1,0 +1,18 @@
+from nada_dsl import *
+
+
+def nada_main():
+    party_alice = Party(name="Alice")
+    party_bob = Party(name="Bob")
+    party_charlie = Party(name="Charlie")
+
+    # Inputs from each party
+    secret1 = SecretInteger(Input(name="secret1", party=party_alice))
+    secret2 = SecretInteger(Input(name="secret2", party=party_bob))
+    secret3 = SecretInteger(Input(name="secret3", party=party_charlie))
+
+    # List of secrets
+    secrets_list = [secret1, secret2, secret3]
+
+    # Return the sum to party_alice
+    return [Output(sum(secrets_list), "sum_list", party_alice) for i in range(3)]

--- a/tests/sum_list.yaml
+++ b/tests/sum_list.yaml
@@ -1,0 +1,8 @@
+---
+program: sum_list
+inputs:
+  secret1: 3
+  secret2: 3
+  secret3: 3
+expected_outputs:
+  sum_list: 9


### PR DESCRIPTION
# New Nada Example

- [ ] I have read the [contributing docs](/NillionNetwork/nada-by-example/blob/main/CONTRIBUTING.md)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/NillionNetwork/nada-by-example/pulls)

## Description

Describe the example you are adding. Provide a clear and concise summary of what the example does, its purpose, and the problem it solves. 

## Use Case

What are the target use cases for the example? 

## Related Issues

Link to the related issue if this PR solves an Issue.

## Optional: add your information for a Nada by Example Contributor POAP

Your Twitter:
Your Ethereum address:
