### PR TITLE
Issue #20 Oblivious Update

### DIFF
--- a/nada-project.toml
+++ b/nada-project.toml
@@ -263,3 +263,8 @@ prime_size = 128
 path = "src/auction_can_tie.py"
 name = "auction_can_tie"
 prime_size = 128
+
+[[programs]]
+path = "src/oblivious_update.py"
+name = "oblivious_update"
+prime_size = 128

--- a/src/oblivious_update.py
+++ b/src/oblivious_update.py
@@ -1,0 +1,31 @@
+from nada_dsl import *
+import nada_numpy as na
+
+### Updates the elements of the list which matches the old_value to a new_value
+def nada_main():
+    party_alice = Party(name="Party_Alice")
+    party_bob = Party(name="Party_Bob")
+
+    # Getting the old and new value to update the list
+    old_value = SecretInteger(Input(name="old_value", party=party_alice))
+    new_value = SecretInteger(Input(name="new_value", party=party_bob))
+
+    size_of_list = 5
+    parties = na.parties(size_of_list)
+
+    # Get the values of the list
+    secrets_list = []
+    for i in range(size_of_list):
+        secrets_list.append(
+            SecretInteger(Input(name="num_" + str(i), party=parties[i]))
+        )
+    
+    # Update the list
+    for i in range(size_of_list):
+        secrets_list[i] = (secrets_list[i] == old_value).if_else(new_value, secrets_list[i])
+
+    return [
+        Output(secrets_list[i], "modified_num_" + str(i + 1), party=parties[i])
+        for i in range(size_of_list)
+    ]
+

--- a/tests/oblivious_update_test.yaml
+++ b/tests/oblivious_update_test.yaml
@@ -1,0 +1,16 @@
+---
+program: oblivious_update
+inputs:
+  new_value: 6
+  num_0: 1
+  num_1: 2
+  num_2: 3
+  num_3: 4
+  num_4: 5
+  old_value: 2
+expected_outputs:
+  modified_num_1: 1
+  modified_num_2: 6
+  modified_num_3: 3
+  modified_num_4: 4
+  modified_num_5: 5


### PR DESCRIPTION
# New Nada Example

- [x] I have read the [contributing docs](/NillionNetwork/nada-by-example/blob/main/CONTRIBUTING.md)
- [x] This is not a duplicate of any [existing pull request](https://github.com/NillionNetwork/nada-by-example/pulls)

## Description

Obliviously update an element of a list if it exists. Checks whether a specific value `old_value` is present in the list. If it is present update the `old_value` to `new_value`.

## Changes

- Added oblivious_update.py to the src/directory.
- Added oblivious_update_test.yaml to the tests/directory for testing the replaced value on the list.
- Updated nada-project.toml to include this new program.

## Related Issues
This pull request addresses the issue [#20 ](https://github.com/NillionNetwork/nada-by-example/issues/20), Which requested a new example for Obliviously updating element which matches a specific value to a new value.

## Optional: add your information for a Nada by Example Contributor POAP

Your Twitter: @apanarun
Your Ethereum address: 0xEd1b1356CB4b6bFC5c77dd7172b753Ba15e14C57
